### PR TITLE
Add Kotest and MockK dependencies and Kotest plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
     id("io.spring.dependency-management")
     id("com.google.protobuf") apply false
     id("org.jlleitschuh.gradle.ktlint") apply false
+    id("io.kotest") version "6.0.0.M4" apply false
 }
 
 java {
@@ -44,6 +45,9 @@ subprojects {
         testImplementation("org.springframework.boot:spring-boot-starter-test")
         testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
         testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+        testImplementation("io.kotest:kotest-runner-junit5:5.9.1")
+        testImplementation("io.kotest:kotest-assertions-core:5.9.1")
+        testImplementation("io.mockk:mockk:1.14.2")
     }
 
     java {


### PR DESCRIPTION
This commit adds the following dependencies to the root build.gradle.kts:
- io.kotest:kotest-runner-junit5:5.9.1
- io.kotest:kotest-assertions-core:5.9.1
- io.mockk:mockk:1.14.2

It also adds the Kotest Gradle plugin:
- id("io.kotest") version "6.0.0.M4" apply false